### PR TITLE
Remove an extra `2.` from a Pig link.

### DIFF
--- a/projects-data/apache_pig.json
+++ b/projects-data/apache_pig.json
@@ -12,7 +12,7 @@
       "url": "https://pig.apache.org/"
     },
     {
-      "text": "2.Pig examples by Alan Gates",
+      "text": "Pig examples by Alan Gates",
       "url": "https://github.com/alanfgates/programmingpig"
     }
   ]


### PR DESCRIPTION
Removing what seems an unnecessary numbered element from Apache Pig's links :pig2: 
